### PR TITLE
Replace deprecated function split() with explode()

### DIFF
--- a/auth/gauth/auth.php
+++ b/auth/gauth/auth.php
@@ -232,7 +232,7 @@ class auth_plugin_gauth extends auth_plugin_base {
     * @param string $string Possibly multi-valued attribute from Identity Provider
     */
     function get_first_string($string) {
-        $list = split( ';', $string);
+        $list = explode( ';', $string);
         $clean_string = trim($list[0]);
 
         return $clean_string;

--- a/blocks/gmail/block_gmail.php
+++ b/blocks/gmail/block_gmail.php
@@ -194,7 +194,7 @@ class block_gmail extends block_list {
                     $servicelink = str_replace('http://mail.google.com/mail','http://mail.google.com/a/'.$this->domain,$servicelink);
 
                     // To Save Space given them option to show first and last or just last name
-                    $authornames = split(" ",$author->get_name());
+                    $authornames = explode(" ",$author->get_name());
                     $author_first = array_shift($authornames);
                     $author_last = array_shift($authornames);
                     // Show first Name
@@ -241,7 +241,7 @@ class block_gmail extends block_list {
             require_once('OAuth.php');
         }
         $consumer  = new OAuthConsumer($this->domain, $this->oauthsecret, NULL);
-        $parts = split('@', $USER->{$this->userfield});
+        $parts = explode('@', $USER->{$this->userfield});
         $user = array_shift($parts);
         $user      = "$user@$this->domain";
         $feed      = 'https://mail.google.com/mail/feed/atom';


### PR DESCRIPTION
Minor change, works fine on 2.5 without the extra stuff I thought would be required. 

This patch just makes a change for PHP 5.3.x compatibility.
